### PR TITLE
added deeper check for drawerToggleAttribute

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -614,7 +614,8 @@ To position the drawer to the right, add `rightDrawer` attribute.
       onClick: function(e) {
         var isTargetToggleElement = e.target &&
           this.drawerToggleAttribute &&
-          e.target.hasAttribute(this.drawerToggleAttribute);
+          (e.target.hasAttribute(this.drawerToggleAttribute) ||
+            (e.srcElement.dataHost && e.srcElement.dataHost.hasAttribute(this.drawerToggleAttribute) ) );
 
         if (isTargetToggleElement) {
           this.togglePanel();


### PR DESCRIPTION
When using the paper-drawer-toggle attribute with a paper-icon-button, the check for the attribute in paper-drawer-panel's onClick function failed because the attribute is not attached to paper-ripple (which is the event target for paper-icon-button), it is instead found in e.srcElement.dataHost.
