### PR TITLE
fix toggle-drawer issue

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -239,12 +239,12 @@ To position the drawer to the right, add `rightDrawer` attribute.
     <iron-selector
         attr-for-selected="id"
         class$="[[_computeIronSelectorClass(narrow, transition, dragging, rightDrawer)]]"
-        on-iron-activate="onSelect"
+        activate-event=""
         selected="[[selected]]">
 
       <div id="main" style$="[[_computeMainStyle(narrow, rightDrawer, drawerWidth)]]">
         <content select="[main]"></content>
-        <div id="scrim"></div>
+        <div id="scrim" on-tap="closeDrawer"></div>
         <div id="edgeSwipeOverlay"
             hidden$="[[_computeSwipeOverlayHidden(narrow, disableEdgeSwipe)]]">
         </div>
@@ -397,7 +397,8 @@ To position the drawer to the right, add `rightDrawer` attribute.
         narrow: {
           reflectToAttribute: true,
           type: Boolean,
-          value: false
+          value: false,
+          notify: true
         },
 
         // Whether the drawer is peeking out from the edge.
@@ -608,9 +609,10 @@ To position the drawer to the right, add `rightDrawer` attribute.
       },
 
       _onTap: function(e) {
-        var isTargetToggleElement = e.target &&
+        var targetElement = Polymer.dom(e).localTarget;
+        var isTargetToggleElement = targetElement &&
           this.drawerToggleAttribute &&
-          e.target.hasAttribute(this.drawerToggleAttribute);
+          targetElement.hasAttribute(this.drawerToggleAttribute);
 
         if (isTargetToggleElement) {
           this.togglePanel();
@@ -701,11 +703,6 @@ To position the drawer to the right, add `rightDrawer` attribute.
         } else {
           s.webkitTransform = this._transformForTranslateX(translateX);
         }
-      },
-
-      onSelect: function(e) {
-        e.preventDefault();
-        this.selected = e.detail.selected;
       }
 
     });


### PR DESCRIPTION
fix https://github.com/PolymerElements/paper-drawer-panel/issues/12
- use Polymer.dom api to get the right localTarget.  (https://github.com/Polymer/polymer/commit/739de807d553d6d7885edd093d1b2b8176196322)
- make `narrow` `notify: true` so we can bind to the property.
- iron-selector has activateEvent set to `click`, paper-drawer-panel shouldn't use the default and instead close the drawer when click on the scrim.
