### PR TITLE
added check to ensure selected node is the paper-drawer-panel

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -720,8 +720,10 @@ To position the drawer to the right, add `rightDrawer` attribute.
       },
 
       onSelect: function(e) {
-        e.preventDefault();
-        this.selected = e.detail.selected;
+	if(e.detail.item.classList.contains('paper-drawer-panel')) {
+	        e.preventDefault();
+        	this.selected = e.detail.selected;
+	}
       }
 
     });


### PR DESCRIPTION
When using paper-tabs inside of paper-drawer-panel, the tabs were rippling but their selection was not being changed. This was because onSelect inside paper-drawer-panel was stopping the even propagation.

I added an if statement to ensure the selected node contained the paper-drawer-panel class.
