### PR TITLE
Remove "private" attribute from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
     "layout"
   ],
   "main": "index.html",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git://github.com/PolymerElements/paper-drawer-panel.git"


### PR DESCRIPTION
Looks like this got left over from a while back.
