### PR TITLE
Fixes #93 - update default responsiveWidth to 600px

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -307,7 +307,7 @@ To customize the scrim:
          */
         responsiveWidth: {
           type: String,
-          value: '640px'
+          value: '600px'
         },
 
         /**


### PR DESCRIPTION
Addresses this request:

> Could you change default responsiveWidth to 600px Breakpoint?
> 
> http://www.google.com/design/spec/layout/adaptive-ui.html#adaptive-ui-breakpoints

which brings us in line with the adaptive-ui breakpoint guidance.
