### PR TITLE
Remove the default background colour

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -146,7 +146,6 @@ Custom property | Description | Default
         top: 0;
         left: 0;
         height: 100%;
-        background-color: white;
 
         -moz-box-sizing: border-box;
         box-sizing: border-box;


### PR DESCRIPTION
This allows for the background colour of the body to be shown through. The documentation says that there is no default colour for the left and right draws but the CSS sets it to white.

I came across this when I have set my background colour of `<body>` to an offwhite colour and the draw stamps on that with a solid `white`. I guess I can specify the custom CSS attributes to get around this but thought I'd submit this as a proposal.
