### PR TITLE
Responsively hide drawer panel @768px: fixes #138

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -465,7 +465,7 @@ Custom property | Description | Default
            */
           responsiveWidth: {
             type: String,
-            value: '600px'
+            value: '768px'
           },
 
           /**


### PR DESCRIPTION
Changes the default window width to responsively hide the drawer panel at 768px, a better value given the width of the drawer panel itself.
