### PR TITLE
Add print media rules

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -143,7 +143,9 @@ Custom property | Description | Default
       }
       
       @media print {
-        :host { position: static }
+        :host {
+          position: static;
+        }
       }
 
       iron-selector > #drawer {

--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -141,6 +141,10 @@ Custom property | Description | Default
         height: 100%;
         overflow: hidden;
       }
+      
+      @media print {
+        :host { position: static }
+      }
 
       iron-selector > #drawer {
         position: absolute;


### PR DESCRIPTION
This makes a page using `paper-header-panel` + `paper-drawer-panel` printable. Without these rules it prints only the first page.

Related: https://github.com/PolymerElements/paper-header-panel/pull/91
