### PR TITLE
Fixes issue #153

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -214,6 +214,10 @@ Custom property | Description | Default
         @apply(--paper-drawer-panel-scrim);
       }
 
+      .narrow-layout > #main >::content > [main] {
+          will-change: transform;
+      }
+        
       .narrow-layout > #drawer {
         will-change: transform;
       }


### PR DESCRIPTION
Fixes issue #153 by creating a stacking context on the `[main]` content so that all its potentially `z-index`ed children are stacked within a context scoped to that element.

## Introduced as little change as possible
The `#scrim` overlay sits over it simply by being added next -- current behavior inchanged.  
Stacking context created with:

    will-change: transform;