### PR TITLE
Fixes#149

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -290,7 +290,7 @@ Custom property | Description | Default
 
     <iron-selector
         attr-for-selected="id"
-        class$="[[_computeIronSelectorClass(narrow, _transition, dragging, rightDrawer, peeking)]]"
+        class$="[[_computeIronSelectorClass(narrow, _transition, dragging, _rightDrawer, peeking)]]"
         activate-event=""
         selected="[[selected]]">
 
@@ -474,7 +474,8 @@ Custom property | Description | Default
            */
           rightDrawer: {
             type: Boolean,
-            value: false
+            value: false,
+            observer: "_rightDrawerChanged"
           },
 
           /**
@@ -597,12 +598,12 @@ Custom property | Description | Default
           }
         },
 
-        _computeIronSelectorClass: function(narrow, transition, dragging, rightDrawer, peeking) {
+        _computeIronSelectorClass: function(narrow, transition, dragging, _rightDrawer, peeking) {
           return classNames({
             dragging: dragging,
             'narrow-layout': narrow,
-            'right-drawer': rightDrawer,
-            'left-drawer': !rightDrawer,
+            'right-drawer': _rightDrawer,
+            'left-drawer': !_rightDrawer,
             transition: transition,
             peeking: peeking
           });
@@ -834,6 +835,18 @@ Custom property | Description | Default
 
         _isDrawerClosed: function(narrow, selected) {
           return !narrow || selected !== 'drawer';
+        },
+
+        _rightDrawerChanged: function() {
+          var transition = this._transition;
+          this._transition = false;
+          this._rightDrawer = this.rightDrawer;
+          this._forceReflow(this.$.drawer);
+          this._transition = transition;
+        },
+
+        _forceReflow: function(element) {
+          element.offsetHeight;
         }
       });
 

--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -155,7 +155,7 @@ Custom property | Description | Default
         @apply(--paper-drawer-panel-drawer-container);
       }
 
-      .transition > #drawer {
+      .transition-drawer {
         transition: -webkit-transform ease-in-out 0.3s, width ease-in-out 0.3s, visibility 0.3s;
         transition: transform ease-in-out 0.3s, width ease-in-out 0.3s, visibility 0.3s;
       }
@@ -290,7 +290,7 @@ Custom property | Description | Default
 
     <iron-selector
         attr-for-selected="id"
-        class$="[[_computeIronSelectorClass(narrow, _transition, dragging, _rightDrawer, peeking)]]"
+        class$="[[_computeIronSelectorClass(narrow, _transition, dragging, rightDrawer, peeking)]]"
         activate-event=""
         selected="[[selected]]">
 
@@ -474,8 +474,7 @@ Custom property | Description | Default
            */
           rightDrawer: {
             type: Boolean,
-            value: false,
-            observer: "_rightDrawerChanged"
+            value: false
           },
 
           /**
@@ -571,7 +570,11 @@ Custom property | Description | Default
          * @method openDrawer
          */
         openDrawer: function() {
-          this.selected = 'drawer';
+          requestAnimationFrame(function() {
+            this.toggleClass("transition-drawer", true, this.$.drawer);
+            this.selected = 'drawer';
+          }.bind(this));
+          
         },
 
         /**
@@ -580,7 +583,10 @@ Custom property | Description | Default
          * @method closeDrawer
          */
         closeDrawer: function() {
-          this.selected = 'main';
+          requestAnimationFrame(function() {
+            this.toggleClass("transition-drawer", true, this.$.drawer);
+            this.selected = 'main';
+          }.bind(this));
         },
 
         _onTransitionEnd: function (e) {
@@ -592,18 +598,23 @@ Custom property | Description | Default
           if (e.propertyName === 'left' || e.propertyName === 'right') {
             this.notifyResize();
           }
-          if (e.propertyName === 'transform' && this.selected === 'drawer') {
-            var focusedChild = this._getAutoFocusedNode();
-            focusedChild && focusedChild.focus();
+          if (e.propertyName === 'transform') {
+            requestAnimationFrame(function() {
+              this.toggleClass("transition-drawer", false, this.$.drawer);
+            }.bind(this));
+            if (this.selected === 'drawer') {
+              var focusedChild = this._getAutoFocusedNode();
+              focusedChild && focusedChild.focus();
+            }
           }
         },
 
-        _computeIronSelectorClass: function(narrow, transition, dragging, _rightDrawer, peeking) {
+        _computeIronSelectorClass: function(narrow, transition, dragging, rightDrawer, peeking) {
           return classNames({
             dragging: dragging,
             'narrow-layout': narrow,
-            'right-drawer': _rightDrawer,
-            'left-drawer': !_rightDrawer,
+            'right-drawer': rightDrawer,
+            'left-drawer': !rightDrawer,
             transition: transition,
             peeking: peeking
           });
@@ -835,18 +846,6 @@ Custom property | Description | Default
 
         _isDrawerClosed: function(narrow, selected) {
           return !narrow || selected !== 'drawer';
-        },
-
-        _rightDrawerChanged: function() {
-          var transition = this._transition;
-          this._transition = false;
-          this._rightDrawer = this.rightDrawer;
-          this._forceReflow(this.$.drawer);
-          this._transition = transition;
-        },
-
-        _forceReflow: function(element) {
-          element.offsetHeight;
         }
       });
 

--- a/test/small-devices.html
+++ b/test/small-devices.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         f.set('forceNarrow', true);
         f._forceNarrowChanged();
 
-        Polymer.Base.async(function() {
+       requestAnimationFrame(function() {
           var drawerBoundingRect = drawer.getBoundingClientRect();
           var mainStyle = window.getComputedStyle(main);
           expect(f._isMainSelected()).to.be.equal(true);
@@ -83,7 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         f.set('forceNarrow', true);
         f._forceNarrowChanged();
 
-        Polymer.Base.async(function() {
+        requestAnimationFrame(function() {
           var drawerBoundingRect = drawer.getBoundingClientRect();
           var mainStyle = window.getComputedStyle(main);
           expect(drawerBoundingRect.right).to.be.equal(f.offsetWidth + 256);
@@ -102,7 +102,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         f._forceNarrowChanged();
         f.openDrawer();
 
-        Polymer.Base.async(function() {
+       requestAnimationFrame(function() {
           var drawerBoundingRect = drawer.getBoundingClientRect();
           var mainStyle = window.getComputedStyle(main);
           expect(f.selected).to.be.equal('drawer');
@@ -123,7 +123,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         f._forceNarrowChanged();
         f.openDrawer();
 
-        Polymer.Base.async(function() {
+        requestAnimationFrame(function() {
           var drawerBoundingRect = drawer.getBoundingClientRect();
           var mainStyle = window.getComputedStyle(main);
           expect(drawerBoundingRect.right).to.be.equal(f.offsetWidth);


### PR DESCRIPTION
Fixes issue #149.

Reproduce the issue: 

1. [https://jsfiddle.net/thisoares/0910ac0y/](https://jsfiddle.net/thisoares/0910ac0y/)
2. Click on the "Open Right Drawer" button. The drawer will appear from the left.

- The drawer is opening is animated using a transition for the transform CSS property.
- When the drawer is on the left, the transition is from **transform: translateX(-100%) to transform: none** when the drawer is opened;
- When the drawer is on the right, the transition is from **transform: translateX(100%) to transform: none** when the drawer is opened;
- The transition duration is 0.3s.
- If the rightDrawer is changed before opening the drawer, a transition will start:
    - from **transform: translateX(-100%) to transform: translateX(100%)** if changing rightDrawer from left to right.
    - from **transform: translateX(100%) to transform: translateX(-100%)** if changing rightDrawer from right to left.
- Before the previous transition ends, we open the drawer. This causes a new end to the transition started in the left step.

Solution: Disabled the drawer transition and enable it only on opening/closing the drawer.

Run the fix: [https://jsfiddle.net/thisoares/rdjxmax4/](https://jsfiddle.net/thisoares/rdjxmax4/)
@blasten @minhlong139