### PR TITLE
Fixes issue #159

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -155,7 +155,7 @@ Custom property | Description | Default
         @apply(--paper-drawer-panel-drawer-container);
       }
 
-      .transition-drawer {
+      .transition > .transition-drawer {
         transition: -webkit-transform ease-in-out 0.3s, width ease-in-out 0.3s, visibility 0.3s;
         transition: transform ease-in-out 0.3s, width ease-in-out 0.3s, visibility 0.3s;
       }
@@ -571,6 +571,7 @@ Custom property | Description | Default
          */
         openDrawer: function() {
           requestAnimationFrame(function() {
+            this._moveDrawer(null);
             this.toggleClass("transition-drawer", true, this.$.drawer);
             this.selected = 'drawer';
           }.bind(this));
@@ -584,6 +585,7 @@ Custom property | Description | Default
          */
         closeDrawer: function() {
           requestAnimationFrame(function() {
+            this._moveDrawer(null);
             this.toggleClass("transition-drawer", true, this.$.drawer);
             this.selected = 'main';
           }.bind(this));
@@ -689,6 +691,7 @@ Custom property | Description | Default
 
         _startEdgePeek: function() {
           this.width = this.$.drawer.offsetWidth;
+          this.toggleClass("transition-drawer", true, this.$.drawer);
           this._moveDrawer(this._translateXForDeltaX(this.rightDrawer ?
               -this.edgeSwipeSensitivity : this.edgeSwipeSensitivity));
           this._setPeeking(true);
@@ -697,6 +700,7 @@ Custom property | Description | Default
         _stopEdgePeek: function() {
           if (this.peeking) {
             this._setPeeking(false);
+            this.toggleClass("transition-drawer", true, this.$.drawer);
             this._moveDrawer(null);
           }
         },
@@ -786,7 +790,6 @@ Custom property | Description | Default
             this._setDragging(false);
             this._transition = true;
             sharedPanel = null;
-            this._moveDrawer(null);
 
             if (this.rightDrawer) {
               this[xDirection ? 'closeDrawer' : 'openDrawer']();


### PR DESCRIPTION
Fixes the issue #159.

Reproduce the issue:

1. https://jsfiddle.net/10wprwvr/
2. Click on the "Open Right Drawer" button.
3. Close the drawer.
4. Swipe from the right edge.
5. The drawer is animated twice.

The PR #158 changed the drawer opening and closing to be done inside a requestAnimationFrame. At the end of a swipe movement, the width is reset outside the rAF block, causing the opening/closing animation to be started from the initial position.

Solution:
Reset the drawer width inside the rAF Block that open or closes the drawer. It also restores the transition on the start and stop of edge peek.

Run the fix:  https://jsfiddle.net/rdjxmax4/4/
@rubenstolk @blasten 