### PR TITLE
Restore missed drawerToggleAttribute

### DIFF
--- a/paper-drawer-panel.js
+++ b/paper-drawer-panel.js
@@ -343,7 +343,7 @@ Polymer({
      * Width of the drawer panel.
      */
     drawerWidth: {type: String, value: '256px'},
-    
+
     /**
      * The attribute on elements that should toggle the drawer on tap, also
      * elements will automatically be hidden in wide layout.

--- a/paper-drawer-panel.js
+++ b/paper-drawer-panel.js
@@ -343,6 +343,12 @@ Polymer({
      * Width of the drawer panel.
      */
     drawerWidth: {type: String, value: '256px'},
+    
+    /**
+     * The attribute on elements that should toggle the drawer on tap, also
+     * elements will automatically be hidden in wide layout.
+     */
+    drawerToggleAttribute: {type: String, value: 'paper-drawer-toggle'},
 
     /**
      * How many pixels on the side of the screen are sensitive to edge


### PR DESCRIPTION
Under Polymer v2 the property should be present in the properties list of the component to work as html attribute